### PR TITLE
Test JS build on github actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
         run: npm install
       - name: eslint
         run: npm run eslint
+      - name: build
+        run: npm run build
       - name: test
         run: npm test
   django:


### PR DESCRIPTION
In my environment, the rollup build seems to be hanging. Errors like this should be caught automatically in github actions and/or jenkins.