### PR TITLE
Downgrade rollup-plugin-css-only to 3.1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-svelte": "^2.8.0",
         "mocha": "^10.0.0",
         "rollup": "^2.3.4",
-        "rollup-plugin-css-only": "^4.2.0",
+        "rollup-plugin-css-only": "^3.1.0",
         "rollup-plugin-svelte": "^7.1.0",
         "rollup-plugin-terser": "^7.0.0",
         "svelte": "~3.50.1"
@@ -4375,18 +4375,31 @@
       }
     },
     "node_modules/rollup-plugin-css-only": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-4.2.0.tgz",
-      "integrity": "sha512-X/8hJvi4Sst0BbFSxxdDVFkiYfNHIHEXiayUnPA7FLWmDlpwTSKMV1yLKv3pgmUlUoxlct9jELRQ3osrEcZFiw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
+      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "5"
+        "@rollup/pluginutils": "4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.12.0"
       },
       "peerDependencies": {
-        "rollup": "<4"
+        "rollup": "1 || 2"
+      }
+    },
+    "node_modules/rollup-plugin-css-only/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/rollup-plugin-svelte": {
@@ -8313,12 +8326,24 @@
       }
     },
     "rollup-plugin-css-only": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-4.2.0.tgz",
-      "integrity": "sha512-X/8hJvi4Sst0BbFSxxdDVFkiYfNHIHEXiayUnPA7FLWmDlpwTSKMV1yLKv3pgmUlUoxlct9jELRQ3osrEcZFiw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
+      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "5"
+        "@rollup/pluginutils": "4"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        }
       }
     },
     "rollup-plugin-svelte": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-svelte": "^2.8.0",
     "mocha": "^10.0.0",
     "rollup": "^2.3.4",
-    "rollup-plugin-css-only": "^4.2.0",
+    "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.0",
     "svelte": "~3.50.1"


### PR DESCRIPTION
I'm not sure what this plugin does, but the v4 upgrade seems to cause the rollup build to hang. Let's downgrade this for now.