### PR TITLE
Remove rollup's serve configuration

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,31 +8,6 @@ import { replace } from "svelte-preprocess";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-  let server;
-
-  function toExit() {
-    if (server) server.kill(0);
-  }
-
-  return {
-    writeBundle() {
-      if (server) return;
-      server = require("child_process").spawn(
-        "npm",
-        ["run", "start", "--", "--dev"],
-        {
-          stdio: ["ignore", "inherit", "inherit"],
-          shell: true,
-        }
-      );
-
-      process.on("SIGTERM", toExit);
-      process.on("exit", toExit);
-    },
-  };
-}
-
 export default {
   input: "media/src/main.js",
   output: {
@@ -78,10 +53,6 @@ export default {
       dedupe: ["svelte"],
     }),
     commonjs(),
-
-    // In dev mode, call `npm run start` once
-    // the bundle has been generated
-    !production && serve(),
 
     // If we're building for production (npm run build
     // instead of npm run dev), minify


### PR DESCRIPTION
Now that we're using the django back-end we don't need to serve this through rollup.