### PR TITLE
Adjust shaderPass resolution

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -281,7 +281,7 @@
         const shaderPass = new ShaderPass(FXAAShader);
         shaderPass.uniforms.resolution.value = new THREE.Vector2(
             1 / (width * 2 * dpr), 1 / (height * 2 * dpr));
-        composer.setSize(width * 4 * dpr, height * 4 * dpr);
+        composer.setSize(width * 2 * dpr, height * 2 * dpr);
         composer.addPass(shaderPass);
 
         shaderPass.renderToScreen = true;


### PR DESCRIPTION
This makes the grid lines a little clearer.

![Screenshot_2022-11-01_11-08-46](https://user-images.githubusercontent.com/59292/199267003-afb7e3c2-b321-4ba5-877e-d9a8fd4be0bb.png)
