### PR TITLE
use TubeGeometry instead of TubeBufferGeometry to fix warning

### DIFF
--- a/media/src/Curve.svelte
+++ b/media/src/Curve.svelte
@@ -129,7 +129,7 @@
         // console.log(a.evaluate(), r(0.5));
 
         let path = new ParametricCurve(1, r, A, B);
-        let geometry = new THREE.TubeBufferGeometry(
+        let geometry = new THREE.TubeGeometry(
             path,
             1000,
             gridStep / 20,
@@ -249,7 +249,7 @@
                     return vec;
                 }, -gridStep*30, gridStep*30);
             }
-            const geometry = new THREE.TubeBufferGeometry(
+            const geometry = new THREE.TubeGeometry(
                 path,
                 1000,
                 gridStep / 20,


### PR DESCRIPTION
This fixes a three.js warning:
> THREE.TubeBufferGeometry has been renamed to THREE.TubeGeometry.

The BufferGeometry stuff used to be in three.js as a more performant but also more complicated version of the standard Geometry class, but it looks like these have been removed.