### PR TITLE
Box rendering: don't use socket if it doesn't exist

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -314,11 +314,13 @@
     const upBox = (thing="box", params=null) => {
         const newBox = { id: uuidv4(), kind: thing, params: params };
 
-        socket.send(JSON.stringify({
-            'message': {
-                newBox: newBox
-            }
-        }));
+        if (socket) {
+            socket.send(JSON.stringify({
+                'message': {
+                    newBox: newBox
+                }
+            }));
+        }
 
         boxes = [...boxes, newBox];
     };


### PR DESCRIPTION
This fixes a problem adding objects outside of a room.