### PR TITLE
Use session_key to determine socket sender/receiver

### DIFF
--- a/mathplayground/asgi.py
+++ b/mathplayground/asgi.py
@@ -11,6 +11,7 @@ import os
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
+from channels.sessions import SessionMiddlewareStack
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mathplayground.settings')
@@ -23,8 +24,10 @@ from mathplayground.rooms import routing  # noqa
 application = ProtocolTypeRouter({
     'http': django_asgi_app,
     'websocket': AllowedHostsOriginValidator(
-        URLRouter(
-            routing.websocket_urlpatterns
+        SessionMiddlewareStack(
+            URLRouter(
+                routing.websocket_urlpatterns
+            )
         )
     ),
 })

--- a/mathplayground/rooms/views.py
+++ b/mathplayground/rooms/views.py
@@ -6,6 +6,12 @@ def index(request):
 
 
 def room(request, room_id):
+    # Make sure the user's session is created.
+    # TODO: is this really necessary? This should be happening
+    # automatically.
+    if not request.session.session_key:
+        request.session.create()
+
     return render(request, 'index.html', {
         'room_id': room_id
     })

--- a/mathplayground/settings.py
+++ b/mathplayground/settings.py
@@ -141,3 +141,11 @@ STATSD_HOST = 'localhost'
 STATSD_PORT = 8125
 
 GRAPHITE_BASE = 'https://graphite.ctl.columbia.edu/render/'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379',
+    }
+}
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'


### PR DESCRIPTION
* Configured redis for session storage

Because we're not planning on using a database or django auth here, I'm thinking we can use the session mechanism to store data for anonymous browser sessions.

This fixes the bug where objects are created twice in the author's environment when sending out a websocket update.