### PR TITLE
Some minor channels adjustments

### DIFF
--- a/mathplayground/rooms/consumers.py
+++ b/mathplayground/rooms/consumers.py
@@ -32,14 +32,14 @@ class RoomsConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_send(
             self.room_group_name,
             {
-                'type': 'chat_message',
+                'type': 'graph_event',
                 'message': message,
                 'session_key': session.session_key,
             }
         )
 
     # Receive message from room group
-    async def chat_message(self, event):
+    async def graph_event(self, event):
         message = event['message']
         session = self.scope['session']
 

--- a/mathplayground/settings.py
+++ b/mathplayground/settings.py
@@ -124,6 +124,7 @@ CHANNEL_LAYERS = {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
             'hosts': [('127.0.0.1', 6379)],
+            'prefix': project + ':asgi',
         },
     },
 }


### PR DESCRIPTION
Two things here:
* Change the channel type we're currently using to "graph_event". We may have other event types in the future.
* Adjust redis prefix used by channels to include the project name. Currently it's just "asgi", which should be fine as this is the only project that's currently using asgi in redis, but that's kind of generic.