### PR TITLE
Use hiredis if available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pyparsing==3.0.9
 PySocks==1.7.1
 python-dateutil==2.8.2
 python-dotenv==0.21.0
-redis==4.3.4
+redis[hiredis]==4.3.4
 requests==2.28.1
 s3transfer==0.6.0
 selenium==4.5.0


### PR DESCRIPTION
redis-py recommends using hiredis. https://github.com/redis/redis-py#installation This change installs the package with hiredis support, which is a minimal redis client.