### PR TITLE
RedisScene.get_state: add use_json option

### DIFF
--- a/mathplayground/rooms/scene.py
+++ b/mathplayground/rooms/scene.py
@@ -22,13 +22,16 @@ class RedisScene:
         key = '{}{}'.format(SCENE_PREFIX, self.room_id)
         self.r.set(key, json.dumps(state))
 
-    def get_state(self):
+    def get_state(self, use_json=False):
         key = '{}{}'.format(SCENE_PREFIX, self.room_id)
 
         state = self.r.get(key)
         if not state:
             # Initial state
             state = '{"objects": []}'
+
+        if use_json:
+            return state
 
         return json.loads(state)
 

--- a/mathplayground/rooms/views.py
+++ b/mathplayground/rooms/views.py
@@ -12,7 +12,7 @@ def room(request, room_id):
         request.session.create()
 
     scene = RedisScene(room_id)
-    state = scene.get_state()
+    state = scene.get_state(True)
 
     return render(request, 'index.html', {
         'room_id': room_id,

--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -277,6 +277,10 @@
     };
 
     let objects = [];
+    if (window.SCENE_STATE) {
+        window.SCENE_STATE = JSON.parse(window.SCENE_STATE);
+    }
+
     if (window.SCENE_STATE && window.SCENE_STATE.objects) {
         objects = window.SCENE_STATE.objects;
     }


### PR DESCRIPTION
Leave the state in JSON syntax when using it to populate the window.SCENE_STATE javascript variable.

This should fix a problem I found on production, where the Python `None` keyword is used like this, which isn't valid javascript:

window.SCENE_STATE = {'objects': [{'uuid':
    'e7e7a38a-66a3-4159-a876-022013001692', 'kind': 'curve',
    'params': {'a': '0', 'b': '2*pi', 'x': 'cos(t)', 'y':
    'sin(t)', 'z': 'cos(5*t)', 'tau': 0, 'color': '#0009a7'}},
    {'uuid': '883f4224-1a5d-4a02-b227-8026826b3364', 'kind':
    'box', 'params': None}]};