### PR TITLE
RedisScene.get_state: add parse_json option

### DIFF
--- a/mathplayground/rooms/scene.py
+++ b/mathplayground/rooms/scene.py
@@ -1,6 +1,7 @@
 import json
 import redis
 from django.conf import settings
+from django.utils.encoding import smart_str
 
 
 SCENE_PREFIX = 'mathplayground:scene:'
@@ -22,13 +23,16 @@ class RedisScene:
         key = '{}{}'.format(SCENE_PREFIX, self.room_id)
         self.r.set(key, json.dumps(state))
 
-    def get_state(self):
+    def get_state(self, parse_json=True):
         key = '{}{}'.format(SCENE_PREFIX, self.room_id)
 
         state = self.r.get(key)
         if not state:
             # Initial state
             state = '{"objects": []}'
+
+        if not parse_json:
+            return smart_str(state)
 
         return json.loads(state)
 

--- a/mathplayground/rooms/views.py
+++ b/mathplayground/rooms/views.py
@@ -12,7 +12,7 @@ def room(request, room_id):
         request.session.create()
 
     scene = RedisScene(room_id)
-    state = scene.get_state()
+    state = scene.get_state(False)
 
     return render(request, 'index.html', {
         'room_id': room_id,


### PR DESCRIPTION
Leave the state as a JSON string when using it to populate the window.SCENE_STATE javascript variable.

This should fix a problem I found on production, where the Python `None` keyword is used like this, which isn't valid javascript:

window.SCENE_STATE = {'objects': [{'uuid':
    'e7e7a38a-66a3-4159-a876-022013001692', 'kind': 'curve',
    'params': {'a': '0', 'b': '2*pi', 'x': 'cos(t)', 'y':
    'sin(t)', 'z': 'cos(5*t)', 'tau': 0, 'color': '#0009a7'}},
    {'uuid': '883f4224-1a5d-4a02-b227-8026826b3364', 'kind':
    'box', 'params': None}]};