### PR TITLE
Don't try to render boxes that don't have params set

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -614,7 +614,7 @@
                                     on:animate={animateIfNotAnimating}
                                     {gridStep}
                                 />
-                            {:else if b.kind === "box"}
+                            {:else if b.kind === "box" && b.params}
                                 <Box
                                     {scene}
                                     render={requestFrameIfNotRequested}


### PR DESCRIPTION
Currently, a SCENE_STATE like this can crash the application:
```
[
    {"uuid": "883f4224-1a5d-4a02-b227-8026826b3364", "kind": "box", "params": null}
]
```
See https://mathplayground.ctl.columbia.edu/rooms/4/ for a live example of this bug.

This change fixes that. Going forward, maybe this calls for some sort of loadScene() function that filters out bad data like this with robust validation and tests. This is related to Evan's work so I will hold off on that for now.