### PR TITLE
CSS cleanup: remove some global button styles

### DIFF
--- a/media/mathplayground/global.css
+++ b/media/mathplayground/global.css
@@ -75,20 +75,6 @@ body,
     padding: 0.25rem 0.5rem;
 }
 
-button {
-    background-color: transparent;
-    color: white;
-    border: none;
-}
-
-button:hover {
-    color: white;
-}
-
-button:active {
-    color: gray;
-}
-
 .container {
     display: grid;
 
@@ -100,10 +86,6 @@ button:active {
     padding: 10px;
 }
 
-label {
-    display: block;
-}
-
 h1 {
     color: white;
     font-size: 1.5rem;
@@ -112,10 +94,6 @@ h1 {
 
 h2 {
     font-size: 1.5rem;
-}
-
-.hidden {
-    display: none;
 }
 
 input {

--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -447,6 +447,7 @@
                             <i class="fa fa-sliders" />
                         </button>
                     </div>
+                    {#if currentMode !== 'session'}
                     <div class="object-box-title d-flex">
                         <ButtonDropdown class="mb-2">
                             <DropdownToggle
@@ -474,6 +475,7 @@
                             </DropdownMenu>
                         </ButtonDropdown>
                     </div>
+                    {/if}
                     {#if currentMode === 'session'}
                         <Session
                             bind:roomId

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -373,13 +373,13 @@
             <strong>Space Curve</strong>
         </span>
         <span>
-            <button
+            <button class="btn"
                 on:click={() => {
                 hidden = !hidden;
                 }}>
                 <i class="fa fa-window-minimize" />
             </button>
-            <button on:click={onClose}>
+            <button class="btn" on:click={onClose}>
                 <i class="fa fa-window-close" />
             </button>
         </span>
@@ -459,13 +459,12 @@
                 <span class="slider round" />
             </label>
             <span class="play-buttons box-4">
-                <button
+                <button class="btn box-1"
                     on:click={() => {
                         frame.visible = true;
                         animation = !animation;
                         if (animation) dispatch("animate");
                     }}
-                    class="box-1"
                 >
                     {#if !animation}
                         <i class="fa fa-play" />
@@ -473,22 +472,20 @@
                         <i class="fa fa-pause" />
                     {/if}
                 </button>
-                <button
+                <button class="btn box-3"
                     on:click={() => {
                         animation = false;
                         render();
                     }}
-                    class="box-3"
                     bind:this={stopButton}
                 >
                     <i class="fa fa-stop" />
                 </button>
-                <button
+                <button class="btn box-4"
                     on:click={() => {
                         params.tau = 0;
                         updateFrame();
                     }}
-                    class="box-4"
                     bind:this={rewButton}
                 >
                     <i class="fa fa-fast-backward" />

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -321,15 +321,14 @@
 <div class="boxItem">
     <div class="box-title">
         <strong>Vector Field</strong>
-        <span
-            ><button
+        <span>
+            <button class="btn"
                  on:click={() => {
                 hidden = !hidden;
-                }}><i class="fa fa-window-minimize" /></button
-                                                          ><button on:click={onClose}>
-                <i class="fa fa-window-close" /></button
-                                                    ></span
-                                                         >
+                }}><i class="fa fa-window-minimize" /></button>
+            <button class="btn" on:click={onClose}>
+                <i class="fa fa-window-close" /></button>
+        </span>
     </div>
     <div hidden={hidden}>
         <div class="container">
@@ -388,13 +387,12 @@
                 <span class="slider round" />
             </label>
 
-        <button
+        <button class="btn box-1"
             on:click={() => {
             flowArrows.visible = true;
             animation = !animation;
             if (animation) dispatch("animate");
             }}
-            class="box-1"
             >
             {#if !animation}
                 <i class="fa fa-play" />
@@ -402,7 +400,7 @@
                 <i class="fa fa-pause" />
             {/if}
         </button>
-        <button
+        <button class="btn box-3"
             on:click={() => {
             animation = false;
             flowArrows.visible = false;
@@ -411,12 +409,11 @@
             maxLength = initFlowArrows(flowArrows, gridMax, params.nVec);
             render();
             }}
-            class="box-3"
             bind:this={stopButton}
             >
             <i class="fa fa-stop" />
         </button>
-        <button
+        <button class="btn box-4"
             on:click={() => {
             freeChildren(flowArrows);
             maxLength = initFlowArrows(flowArrows, gridMax, params.nVec);
@@ -424,7 +421,6 @@
             freeTrails();
             render();
             }}
-            class="box-4"
             bind:this={rewButton}
             >
             <i class="fa fa-fast-backward" />

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -794,10 +794,10 @@
     <div class="box-title">
         <strong>Graph of function</strong>
         <span>
-            <button on:click={() => {hidden = !hidden;}}>
+            <button class="btn" on:click={() => {hidden = !hidden;}}>
                 <i class="fa fa-window-minimize" />
             </button>
-            <button on:click={onClose}>
+            <button class="btn" on:click={onClose}>
                 <i class="fa fa-window-close" />
             </button>
         </span>
@@ -896,7 +896,7 @@
                 Levels
             </span>
             <span class="box-2">
-                <button on:click={activateLevelElevator} class="box-2">
+                <button class="btn box-2" on:click={activateLevelElevator}>
                     {#if data.levelDelta === 1}
                         Up <i class="fa fa-caret-up" />
                     {:else}
@@ -938,7 +938,7 @@
                 class="box box-2"
             />
             <span class="play-buttons box-4">
-                <button
+                <button class="btn box-1"
                     on:click={() => {
                     data.animateTime = !data.animateTime;
                     if (data.animateTime) {
@@ -946,7 +946,6 @@
                     dispatch("animate");
                     }
                     }}
-                    class="box-1"
                     >
                     {#if !data.animateTime}
                         <i class="fa fa-play" />
@@ -954,21 +953,19 @@
                         <i class="fa fa-pause" />
                     {/if}
                 </button>
-                <button
+                <button class="btn box-3"
                     on:click={() => {
                     data.animateTime = false;
                     render();
                     }}
-                    class="box-3"
                     >
                     <i class="fa fa-stop" />
                 </button>
-                <button
+                <button class="btn box-4"
                     on:click={() => {
                     data.tau = 0;
                     evolveSurface(params.t0);
                     }}
-                    class="box-4"
                     >
                     <i class="fa fa-fast-backward" />
                 </button>

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -363,14 +363,12 @@
             </span>
         </span>
         <span
-            ><button
+            ><button class="btn"
                  on:click={() => {
                 hidden = !hidden;
-                }}><i class="fa fa-window-minimize" /></button
-                                                          ><button on:click={onClose}>
-                <i class="fa fa-window-close" /></button
-                                                    ></span
-                                                         >
+                }}><i class="fa fa-window-minimize" /></button>
+            <button class="btn" on:click={onClose}>
+                <i class="fa fa-window-close" /></button></span>
     </div>
     <div hidden={hidden}>
         <div class="container">

--- a/media/src/objects/ParSurf.svelte
+++ b/media/src/objects/ParSurf.svelte
@@ -279,7 +279,10 @@
 
 <div class="boxItem">
     <div class="box-title">
-        <strong>Parametric surface</strong> <span><button on:click={() => {hidden = !hidden}}><i class="fa fa-window-minimize"></i></button><button on:click={onClose}> <i class="fa fa-window-close"></i></button></span>
+        <strong>Parametric surface</strong> <span>
+            <button class="btn"on:click={() => {hidden = !hidden}}><i class="fa fa-window-minimize"></i></button>
+            <button class="btn" on:click={onClose}> <i class="fa fa-window-close"></i></button>
+        </span>
     </div>
     <div hidden={hidden}>
         <div class="container">

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -106,13 +106,13 @@
     <div class="box-title">
         <span><strong>Vector</strong> <M size="sm">\langle a, b, c \rangle</M></span>
         <span>
-            <button
+            <button class="btn"
                 on:click={() => { hidden = !hidden; }}
                 aria-label="Minimize Object Window"
             >
                 <i class="fa fa-window-minimize" />
             </button>
-            <button
+            <button class="btn"
                 on:click={onClose}
                 aria-label="Delete Object"
             >


### PR DESCRIPTION
We should be relying on bootstrap for these standard styles, with less custom CSS for standard elements.