### PR TITLE
Don't use Object.hasOwn()

### DIFF
--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -27,7 +27,7 @@
         show: true,
     };
 
-    if (!Object.hasOwn(params, 'show')) {
+    if (!('show' in params)) {
         params.show = true;
     }
 

--- a/media/src/utils.js
+++ b/media/src/utils.js
@@ -136,7 +136,7 @@ function marchingSquare(a, b, c, d, e, lev) {
     const endPoints = [];
     let edges = [];
 
-    if (Object.hasOwn(squaresTable, code)) {
+    if (code in squaresTable) {
         edges = squaresTable[code];
     } else {
         if ((a < lev && e < lev) || (!(a < lev) && !(e < lev))) {


### PR DESCRIPTION
Older but recent versions of Safari (e.g. 14.1.1) don't support Object.hasOwn():
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility

The `in` keyword has wider support:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in#browser_compatibility