### PR TITLE
Fix params cloning in params updater

### DIFF
--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -33,7 +33,7 @@
         params.color = "#FFDD33";
     }
 
-    let oldParams = params;
+    let oldParams = Object.assign({}, params);
 
     // This pattern mimicks the componentDidUpdate/prevState stuff
     // that's used in React. The goal here is to only call the

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -25,7 +25,7 @@
         nVec: 6,
     };
 
-    let oldParams = params;
+    let oldParams = Object.assign({}, params);
 
     $: {
         if (

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -36,7 +36,7 @@
         color: "#3232ff",
     };
 
-    let oldParams = params;
+    let oldParams = Object.assign({}, params);
 
     // See Curve.svelte for explanation of this stuff
     $: {

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -31,7 +31,7 @@
         f: "2",
     };
 
-    let oldParams = params;
+    let oldParams = Object.assign({}, params);
 
     $: {
         if (

--- a/media/src/objects/ParSurf.svelte
+++ b/media/src/objects/ParSurf.svelte
@@ -27,7 +27,7 @@
         nX: 30,
     };
 
-    let oldParams = params;
+    let oldParams = Object.assign({}, params);
 
     // See Curve.svelte for explanation of this stuff
     $: {


### PR DESCRIPTION
Assigning to a new variable doesn't clone a javascript object. This was my mistake - we need to clone this in a different way: Object.assign() is a good way to do this.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign