### PR TITLE
Remove unused gridMax property from Vector

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -715,7 +715,6 @@
                                         onUpdate={() => objects = updateObject(b, objects)}
                                         params={b.params}
                                         {gridStep}
-                                        {gridMax}
                                     />
                                 {/if}
                             </div>


### PR DESCRIPTION
This fixes the JS warning:
> `<Vector>` was created with unknown prop 'gridMax'