### PR TITLE
Disabled css menu flip

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -445,9 +445,9 @@
 <main>
     <canvas bind:this={canvas} id="c" />
 
-    <div class="info" class:flipInfo>
+    <div class="info">
         <div class="info-inner">
-            <div class="chapterBox">
+            <div class="chapterBox" hidden={flipInfo}>
                 <div class="collapse-info" hidden={shadeUp}>
                     <div class="d-flex mb-2">
                         <h1 class="flex-grow-1 px-2">
@@ -524,7 +524,7 @@
                 </button>
             </div>
 
-            <div class="objectBoxOuter">
+            <div class="objectBoxOuter" hidden={!flipInfo}>
                 <div class="collapse-info" hidden={shadeUp}>
                     <div class="object-box-title d-flex mb-2">
                         <h2 class="flex-grow-1 px-2">3D Objects</h2>
@@ -795,10 +795,6 @@
         transform-style: preserve-3d;
     }
 
-    .info.flipInfo .info-inner {
-        transform: rotateY(180deg);
-    }
-
     .chapterBox,
     .objectBoxOuter {
         position: absolute;
@@ -819,19 +815,6 @@
 
     .chapterBox {
         text-align: unset;
-    }
-
-    .objectBoxOuter {
-        transform: rotateY(180deg);
-        opacity: 0;
-    }
-
-    .info.flipInfo .chapterBox {
-        opacity: 0;
-    }
-
-    .info.flipInfo .objectBoxOuter {
-        opacity: 1;
     }
 
     .objectBoxInner {


### PR DESCRIPTION
The flip menu was interfering with canvas interactions. The inactive side of the flip was still interactive and any invisible elements that extended down further than the visible menu would prevent canvas interactions. You could even click invisible buttons.

We can restore the flip aesthetic, but that is purely Marc and Drew's domain. I'd recommend against it though. As it stands I would actually recommend restructuring `App.svelte`. There are some accessibility issues that are being overlooked for the sake of bug fixes and getting the MVP out ready. Though now that the elements are hidden that may improve tab navigation.