### PR TITLE
Add mathjs input error handling

### DIFF
--- a/media/src/form-components/ObjectParamInput.svelte
+++ b/media/src/form-components/ObjectParamInput.svelte
@@ -9,14 +9,17 @@
     export let initialValue;
     export let onBlur;
     export let type = 'text';
-    export let className = 'box box-2';
+    export let className = 'form-control form-control-sm box box-2';
+
+    // Flag to determine whether this component is in an error state.
+    export let error = false;
 
     let submittedValue = initialValue;
 </script>
 
 <input
     type={type}
-    class={className}
+    class={className + (error ? ' is-invalid' : '')}
     on:blur={(e) => {
         submittedValue = e.target.value;
         onBlur(submittedValue);

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -28,7 +28,7 @@
         color: "#FFDD33",
     };
 
-    let paramError = {
+    let paramErrors = {
         a: false,
         b: false,
         x: false,
@@ -133,23 +133,23 @@
 
         try {
             evalX = x.evaluate({ t: t });
-            paramError.x = false;
+            paramErrors.x = false;
         } catch (e) {
-            paramError.x = true;
+            paramErrors.x = true;
         }
 
         try {
             evalY = y.evaluate({ t: t });
-            paramError.y = false;
+            paramErrors.y = false;
         } catch (e) {
-            paramError.y = true;
+            paramErrors.y = true;
         }
 
         try {
             evalZ = z.evaluate({ t: t });
-            paramError.z = false;
+            paramErrors.z = false;
         } catch (e) {
-            paramError.z = true;
+            paramErrors.z = true;
         }
 
         return new THREE.Vector3(evalX, evalY, evalZ);
@@ -189,17 +189,17 @@
 
         try {
             A = math.parse(a).evaluate();
-            paramError.a = false;
+            paramErrors.a = false;
         } catch (e) {
-            paramError.a = true;
+            paramErrors.a = true;
             return;
         }
 
         try {
             B = math.parse(b).evaluate();
-            paramError.b = false;
+            paramErrors.b = false;
         } catch (e) {
-            paramError.b = true;
+            paramErrors.b = true;
             return;
         }
 
@@ -293,7 +293,7 @@
         let curvature = 0;
 
         const rVec = evalXYZ(x, y, z, T);
-        if (Object.values(paramError).some((x) => x === true)) {
+        if (Object.values(paramErrors).some((x) => x === true)) {
             // There's a param error. Don't finish updating the frame,
             // just return. The appropriate input will be set to
             // invalid state.
@@ -459,7 +459,7 @@
         <div class="container">
             <span class="box-1"><M size="sm">x(t) =</M></span>
             <ObjectParamInput
-                error={paramError.x}
+                error={paramErrors.x}
                 initialValue={params.x}
                 onBlur={(newVal) => {
                     params.x = newVal;
@@ -468,7 +468,7 @@
                 }} />
             <span class="box-1"><M size="sm">y(t) =</M></span>
             <ObjectParamInput
-                error={paramError.y}
+                error={paramErrors.y}
                 initialValue={params.y}
                 onBlur={(newVal) => {
                     params.y = newVal;
@@ -478,7 +478,7 @@
 
             <span class="box-1"><M size="sm">z(t) =</M></span>
             <ObjectParamInput
-                error={paramError.z}
+                error={paramErrors.z}
                 initialValue={params.z}
                 onBlur={(newVal) => {
                     params.z = newVal;
@@ -488,7 +488,7 @@
 
             <ObjectParamInput
                 className="form-control form-control-sm box"
-                error={paramError.a}
+                error={paramErrors.a}
                 initialValue={params.a}
                 onBlur={(newVal) => {
                     params.a = newVal;
@@ -498,7 +498,7 @@
             <span class="box box-3"><M size="sm">\leq t \leq</M></span>
             <ObjectParamInput
                 className="form-control form-control-sm box"
-                error={paramError.b}
+                error={paramErrors.b}
                 initialValue={params.b}
                 onBlur={(newVal) => {
                     params.b = newVal;

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -28,6 +28,14 @@
         color: "#FFDD33",
     };
 
+    let paramError = {
+        a: false,
+        b: false,
+        x: false,
+        y: false,
+        z: false
+    };
+
     if (!params.color) {
         params.color = "#FFDD33";
     }
@@ -111,6 +119,42 @@
         updateFrame();
     };
 
+    /**
+     * Eval x, y, and z mathjs objects on the given t value.
+     *
+     * Catch mathjs errors as necessary.
+     *
+     * Returns a three.js Vector.
+     */
+    const evalXYZ = function(x, y, z, t) {
+        let evalX = 0;
+        let evalY = 0;
+        let evalZ = 0;
+
+        try {
+            evalX = x.evaluate({ t: t });
+            paramError.x = false;
+        } catch (e) {
+            paramError.x = true;
+        }
+
+        try {
+            evalY = y.evaluate({ t: t });
+            paramError.y = false;
+        } catch (e) {
+            paramError.y = true;
+        }
+
+        try {
+            evalZ = z.evaluate({ t: t });
+            paramError.z = false;
+        } catch (e) {
+            paramError.z = true;
+        }
+
+        return new THREE.Vector3(evalX, evalY, evalZ);
+    };
+
     let TNB = false
     let osculatingCircle = false;
     let hidden = false;
@@ -142,9 +186,24 @@
     const updateCurve = function() {
         const { a, b, x, y, z } = params;
         let A, B, X, Y, Z;
+
         try {
             A = math.parse(a).evaluate();
+            paramError.a = false;
+        } catch (e) {
+            paramError.a = true;
+            return;
+        }
+
+        try {
             B = math.parse(b).evaluate();
+            paramError.b = false;
+        } catch (e) {
+            paramError.b = true;
+            return;
+        }
+
+        try {
             [X, Y, Z] = math.parse([x, y, z]);
             goodParams["a"] = A;
             goodParams["b"] = B;
@@ -160,12 +219,9 @@
             startAnimation(false);
         }
 
-        const r = (t) =>
-              new THREE.Vector3(
-                  X.evaluate({ t: t }),
-                  Y.evaluate({ t: t }),
-                  Z.evaluate({ t: t })
-              );
+        const r = (t) => {
+            return evalXYZ(X, Y, Z, t);
+        }
 
         let path = new ParametricCurve(1, r, A, B);
         let geometry = new THREE.TubeGeometry(
@@ -236,12 +292,16 @@
         const T = a + (b - a) * tau;
         let curvature = 0;
 
+        const rVec = evalXYZ(x, y, z, T);
+        if (Object.values(paramError).some((x) => x === true)) {
+            // There's a param error. Don't finish updating the frame,
+            // just return. The appropriate input will be set to
+            // invalid state.
+            return;
+        }
+
         const dr = {
-            r: new THREE.Vector3(
-                x.evaluate({ t: T }),
-                y.evaluate({ t: T }),
-                z.evaluate({ t: T })
-            ),
+            r: rVec,
             v: new THREE.Vector3(
                 (x.evaluate({ t: T + dt / 2 }) - x.evaluate({ t: T - dt / 2 })) / dt,
                 (y.evaluate({ t: T + dt / 2 }) - y.evaluate({ t: T - dt / 2 })) / dt,
@@ -399,6 +459,7 @@
         <div class="container">
             <span class="box-1"><M size="sm">x(t) =</M></span>
             <ObjectParamInput
+                error={paramError.x}
                 initialValue={params.x}
                 onBlur={(newVal) => {
                     params.x = newVal;
@@ -407,6 +468,7 @@
                 }} />
             <span class="box-1"><M size="sm">y(t) =</M></span>
             <ObjectParamInput
+                error={paramError.y}
                 initialValue={params.y}
                 onBlur={(newVal) => {
                     params.y = newVal;
@@ -416,6 +478,7 @@
 
             <span class="box-1"><M size="sm">z(t) =</M></span>
             <ObjectParamInput
+                error={paramError.z}
                 initialValue={params.z}
                 onBlur={(newVal) => {
                     params.z = newVal;
@@ -424,7 +487,8 @@
                 }} />
 
             <ObjectParamInput
-                className="box"
+                className="form-control form-control-sm box"
+                error={paramError.a}
                 initialValue={params.a}
                 onBlur={(newVal) => {
                     params.a = newVal;
@@ -433,7 +497,8 @@
                 }} />
             <span class="box box-3"><M size="sm">\leq t \leq</M></span>
             <ObjectParamInput
-                className="box"
+                className="form-control form-control-sm box"
+                error={paramError.b}
                 initialValue={params.b}
                 onBlur={(newVal) => {
                     params.b = newVal;

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -24,6 +24,15 @@
         show: true,
     };
 
+    let paramErrors = {
+        a: false,
+        b: false,
+        c: false,
+        x: false,
+        y: false,
+        z: false
+    };
+
     if (!params.color) {
         params.color = "#FF0000";
     }
@@ -61,10 +70,57 @@
 
     const updateCurve = function() {
         const { a, b, c, x, y, z } = params;
+        const [pA, pB, pC, pX, pY, pZ] = math.parse([a, b, c, x, y, z]);
+        let A, B, C, X, Y, Z;
 
-        const [A, B, C, X, Y, Z] = math
-              .parse([a, b, c, x, y, z])
-              .map((item) => item.evaluate());
+        try {
+            A = pA.evaluate();
+            paramErrors.a = false;
+        } catch (e) {
+            paramErrors.a = true;
+            return;
+        }
+
+        try {
+            B = pB.evaluate();
+            paramErrors.b = false;
+        } catch (e) {
+            paramErrors.b = true;
+            return;
+        }
+
+        try {
+            C = pC.evaluate();
+            paramErrors.c = false;
+        } catch (e) {
+            paramErrors.c = true;
+            return;
+        }
+
+        try {
+            X = pX.evaluate();
+            paramErrors.x = false;
+        } catch (e) {
+            paramErrors.x = true;
+            return;
+        }
+
+        try {
+            Y = pY.evaluate();
+            paramErrors.y = false;
+        } catch (e) {
+            paramErrors.y = true;
+            return;
+        }
+
+        try {
+            Z = pZ.evaluate();
+            paramErrors.z = false;
+        } catch (e) {
+            paramErrors.z = true;
+            return;
+        }
+
 
         const v = new THREE.Vector3(A, B, C);
 
@@ -140,6 +196,7 @@
         <div class="container">
             <span class="box-1"><M size="sm">a =</M></span>
             <ObjectParamInput
+                error={paramErrors.a}
                 initialValue={params.a}
                 onBlur={(newVal) => {
                     // Set the new param in Vector once blur has happened
@@ -150,6 +207,7 @@
 
             <span class="box-1"><M size="sm">b =</M></span>
             <ObjectParamInput
+                error={paramErrors.b}
                 initialValue={params.b}
                 onBlur={(newVal) => {
                     params.b = newVal;
@@ -159,6 +217,7 @@
 
             <span class="box-1"><M size="sm">c =</M></span>
             <ObjectParamInput
+                error={paramErrors.c}
                 initialValue={params.c}
                 onBlur={(newVal) => {
                     params.c = newVal;
@@ -170,6 +229,7 @@
 
             <span class="box-1"><M size="sm">p_1 =</M></span>
             <ObjectParamInput
+                error={paramErrors.x}
                 initialValue={params.x}
                 onBlur={(newVal) => {
                     params.x = newVal;
@@ -179,6 +239,7 @@
 
             <span class="box-1"><M size="sm">p_2 =</M></span>
             <ObjectParamInput
+                error={paramErrors.y}
                 initialValue={params.y}
                 onBlur={(newVal) => {
                     params.y = newVal;
@@ -188,6 +249,7 @@
 
             <span class="box-1"><M size="sm">p_3 =</M></span>
             <ObjectParamInput
+                error={paramErrors.z}
                 initialValue={params.z}
                 onBlur={(newVal) => {
                     params.z = newVal;


### PR DESCRIPTION
Here's a scheme we can use to display errors to the user when mathjs evaluation fails, and not crash the scene. The UI is using bootstrap's form validation `is-invalid` error state. https://getbootstrap.com/docs/5.3/forms/validation/#server-side

![Screenshot_2023-02-02_13-36-27](https://user-images.githubusercontent.com/59292/216418874-d95fa2b1-4e02-47bf-8130-0e3fae82f4d3.png)

I created two tickets for this that are basically the same issue:
#296 #295 

I'll implement this for the rest of the objects wherever makes sense now.