### PR TITLE
Update t-display

### DIFF
--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -439,7 +439,7 @@
         render();
     });
 
-    const texString1 = `t = ${stringifyT(params)}`;
+    $: texString1 = `t = ${stringifyT(params)}`;
 </script>
 
 <div class="boxItem">


### PR DESCRIPTION
For space curves, the display of the $t$-value next to the slider wasn't dynamically updated so the user did not know which t-value they were selecting. Quick fix.