### PR TITLE
Remove unused svelte-preprocess package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "mathjs": "^11.5.1",
     "sirv-cli": "^2.0.2",
     "stats.js": "^0.17.0",
-    "svelte-preprocess": "^5.0.0",
     "sveltestrap": "^5.9.0",
     "three": "^0.149.0",
     "uuid": "^9.0.0"


### PR DESCRIPTION
Our use of this package was removed in this PR:
https://github.com/ccnmtl/mathplayground/pull/287