### PR TITLE
Function Graph object: fix parse error in main function

### DIFF
--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -332,7 +332,15 @@
             return;
         }
 
-        const [C, D, Z] = math.parse([c, d, z]);
+        let C, D, Z;
+        try {
+            [C, D, Z] = math.parse([c, d, z]);
+            paramErrors.z = false;
+        } catch (e) {
+            paramErrors.z = true;
+            console.error('Parse error in main function!');
+            return;
+        }
 
         const geometry = new ParametricGeometry(
             (u, v, vec) => {


### PR DESCRIPTION
This fixes a bug where the JS can crash by introducing a parse error into the main function, e.g. mis-matched parentheses. Just delete the final paren from the default expression and press enter, to reproduce this bug.

These changes fix that, and allow the error to be displayed properly to the user.