### PR TITLE
Downgrade redis to 4.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pyparsing==3.0.9
 PySocks==1.7.1
 python-dateutil==2.8.2
 python-dotenv==0.21.0
-redis[hiredis]==4.5.0
+redis[hiredis]==4.4.0
 requests==2.28.1
 s3transfer==0.6.0
 selenium==4.8.0


### PR DESCRIPTION
It looks like the new 4.5.0 version causes some connection issues, at least in my development environment. We'll have to investigate here.