### PR TITLE
makeSocket: remove onclose handler - closes #324

### DIFF
--- a/media/src/rooms.js
+++ b/media/src/rooms.js
@@ -36,10 +36,6 @@ const makeSocket = function(roomId, handleMessage=null) {
         socket.onmessage = handleMessage;
     }
 
-    socket.onclose = function() {
-        console.error('Chat socket closed unexpectedly');
-    };
-
     return socket;
 };
 


### PR DESCRIPTION
Sockets are closed when the user navigates to a new URL route, so, this isn't really "unexpected" at all.