### PR TITLE
downgrade typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ trio==0.22.0
 trio-websocket==0.9.2
 Twisted==22.10.0
 txaio==23.1.1
-typing_extensions==4.5.0
+typing_extensions==4.4.0
 urllib3==1.26.12
 webdriver-manager==3.8.4
 wrapt==1.14.1


### PR DESCRIPTION
The jenkins build is failing with this error, since the typing-extensions upgrade:
> selenium.common.exceptions.WebDriverException: Message: unknown error:
> unable to discover open pages

I want to see if this revert fixes the issue.

reverts 940d46044a29076e5af27173634e23f41506c79b