### PR TITLE
CSS fix: .boxItem['border'] duplicate

### DIFF
--- a/media/mathplayground/global.css
+++ b/media/mathplayground/global.css
@@ -66,7 +66,6 @@ body,
 .boxItem {
     flex: auto;
     background-color: rgba(0, 0, 0, 0.7);
-    border: 1px solid black;
     border-radius: 1rem;
     border: 5px solid transparent;
 }


### PR DESCRIPTION
The visual representation wasn't working. The border property probably got duplicated during a rebase/merge. Fixed it now