### PR TITLE
Prevent users from answering multiple times

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -427,10 +427,12 @@
     let currentMode = 'intro';
 
     let pollResponses = {};
+    let userResponseList = {};
 
     const handleSocketMessage = function (e) {
         const data = JSON.parse(e.data);
-        if (data.message.pollResponse) {
+        if (data.message.pollResponse && !(data.session_key in userResponseList)) {
+            userResponseList[data.session_key] = true;
             let choice = data.message.pollResponse;
             if (choice in pollResponses){
                 pollResponses[choice]++;


### PR DESCRIPTION
This fails open, meaning that if a student leaves the page before submitting they aren't locked out of the poll. If a student submits and refreshes the page then the poll will reappear but the submission will not count.

It could be set to accept the last poll submitted by each student, but I wasn't sure if Drew wanted students changing their answers at the last second for one reason or another. After all they aren't being graded. There are no consequences for getting it wrong.