### PR TITLE
Fix crash when loading app with no polls in localStorage

### DIFF
--- a/media/src/polls/Polls.svelte
+++ b/media/src/polls/Polls.svelte
@@ -19,7 +19,7 @@
 
     let polls = loadPolls();
     // Init empty polls to some basic examples
-    if (polls.length === 0) {
+    if (polls && polls.length === 0) {
         polls = [
             new Poll(1, 'Question test', ['a', 'b', 'c']),
             new Poll(1, 'Question test 2', ['a', 'b', 'c', 'd']),

--- a/media/src/polls/utils.js
+++ b/media/src/polls/utils.js
@@ -18,7 +18,7 @@ const loadPolls = function() {
         polls = [];
     }
 
-    return polls;
+    return polls || [];
 };
 
 export {


### PR DESCRIPTION
For example, in a private tab.

These changes fix this error:
![Screenshot_2023-03-01_11-13-48](https://user-images.githubusercontent.com/59292/222198253-69180299-31a7-4dbe-817d-431556b8c732.png)
