### PR TITLE
Handle makeRoom with basic form POST

### DIFF
--- a/mathplayground/main/views.py
+++ b/mathplayground/main/views.py
@@ -1,6 +1,19 @@
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+from django.urls import reverse
+from mathplayground.rooms.scene import make_room
 
 
-# Create your views here.
+@require_http_methods(['GET', 'POST'])
 def index(request):
+    if request.method == 'POST':
+        data = request.POST
+        room_id = make_room(
+            data.get('objects'),
+            request.session.session_key)
+
+        return HttpResponseRedirect(
+            reverse('room', args=[room_id]))
+
     return render(request, 'index.html')

--- a/mathplayground/rooms/consumers.py
+++ b/mathplayground/rooms/consumers.py
@@ -100,12 +100,6 @@ class RoomsConsumer(AsyncWebsocketConsumer):
         elif message.get('broadcastPoll'):
             new_poll = message.get('broadcastPoll', {})
             state['poll'] = new_poll
-        elif 'setHost' in message or message.get('setHost'):
-            new_scene_objs = message.get('setHost', [])
-            state = {
-                'host': session.session_key,
-                'objects': new_scene_objs
-            }
 
         scene.save_state(state)
 

--- a/mathplayground/rooms/scene.py
+++ b/mathplayground/rooms/scene.py
@@ -1,4 +1,5 @@
 import json
+import random
 from datetime import timedelta
 import redis
 from django.conf import settings
@@ -102,3 +103,21 @@ class RedisScene:
 
         state['objects'] = objects
         return state
+
+
+def make_room_id():
+    return round(random.random() * 1000) + 1
+
+
+def make_room(objects=[], session_key=None):
+    """Make a new room from scratch. Record host's session key."""
+    room_id = make_room_id()
+
+    scene = RedisScene(room_id)
+    state = {
+        'host': session_key,
+        'objects': json.loads(objects),
+    }
+    scene.save_state(state)
+
+    return room_id

--- a/mathplayground/rooms/urls.py
+++ b/mathplayground/rooms/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
 
+from mathplayground.main.views import index
 from . import views
 
+
 urlpatterns = [
-    path('', views.index, name='index'),
+    path('', index, name='index'),
     path('<int:room_id>/', views.room, name='room'),
 ]

--- a/mathplayground/rooms/views.py
+++ b/mathplayground/rooms/views.py
@@ -2,10 +2,6 @@ from django.shortcuts import render
 from mathplayground.rooms.scene import RedisScene
 
 
-def index(request):
-    return render(request, 'index.html')
-
-
 def room(request, room_id):
     # Make sure the user's session is created.
     if not request.session.session_key:

--- a/mathplayground/settings_production.py
+++ b/mathplayground/settings_production.py
@@ -21,6 +21,10 @@ MEDIA_URL = S3_URL + 'uploads/'
 AWS_LOCATION = 'media/'
 AWS_QUERYSTRING_AUTH = False
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://3demos.ctl.columbia.edu'
+]
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/mathplayground/settings_staging.py
+++ b/mathplayground/settings_staging.py
@@ -19,6 +19,10 @@ MEDIA_URL = S3_URL + 'uploads/'
 AWS_LOCATION = 'media/'
 AWS_QUERYSTRING_AUTH = False
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://3demos.stage.ctl.columbia.edu'
+]
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/mathplayground/templates/index.html
+++ b/mathplayground/templates/index.html
@@ -4,6 +4,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width,initial-scale=1">
+        <meta id="csrf-token" name="csrf-token" content="{{csrf_token}}">
 
         <title>3Demos</title>
 

--- a/media/src/modes/Session.svelte
+++ b/media/src/modes/Session.svelte
@@ -1,7 +1,6 @@
 <script>
     import Poll from '../polls/Poll.svelte';
     import {getRoomUrl} from '../utils.js';
-    import {makeSocket, setHost, makeRoomId} from '../rooms';
 
     export let roomId;
     export let socket;
@@ -16,22 +15,11 @@
 
     let joinRoomId = '';
 
+    const csrfToken = document.querySelector(
+        'meta[name="csrf-token"]').content;
+
     const onJoinRoom = (joinRoomId) => {
         window.location.href = getRoomUrl(joinRoomId);
-    };
-
-    const onMakeRoom = () => {
-        const newRoomId = makeRoomId();
-
-        socket = makeSocket(newRoomId);
-        // Need to wait for socket's readyState to be open
-        // to send messages.
-        // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
-        socket.addEventListener('open', () => {
-            // Become the host of this new room.
-            setHost(socket, objects);
-            window.location.href = getRoomUrl(newRoomId);
-        });
     };
 </script>
 
@@ -62,9 +50,13 @@
 
     <hr />
 
-    <button
-        type="button" class="btn btn-primary"
-        on:click={onMakeRoom}>
-        Make Room
-    </button>
+    <form method="post">
+        <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+
+        <input type="hidden" name="objects" value={JSON.stringify(objects)} />
+
+        <button type="submit" class="btn btn-primary">
+            Make Room
+        </button>
+    </form>
 {/if}

--- a/media/src/rooms.js
+++ b/media/src/rooms.js
@@ -11,15 +11,6 @@ const getRoomId = function(urlpath) {
 };
 
 /**
- * Generate an ID for a new room.
- *
- * Returns a random number between 1 and 1000.
- */
-const makeRoomId = function() {
-    return Math.round(Math.random() * 1000) + 1;
-};
-
-/**
  * makeSocket
  *
  * Make a WebSocket with the given room name. Connects to a
@@ -40,21 +31,7 @@ const makeSocket = function(roomId, handleMessage=null) {
     return socket;
 };
 
-const setHost = (socket=null, objects=[]) => {
-    if (socket) {
-        socket.send(JSON.stringify({
-            message: {
-                setHost: objects
-            }
-        }));
-    } else {
-        console.error('Can\'t set host: no socket present');
-    }
-};
-
 export {
     getRoomId,
-    makeRoomId,
-    makeSocket,
-    setHost
+    makeSocket
 };


### PR DESCRIPTION
Closes #356

Some unit tests for this new form code are in order, but this is working as is and gets rid of the extra socket connection when making a room.

Django >4.1 requires CSRF_TRUSTED_ORIGINS to be set for csrf to work in form POSTs. So this will need to be added the the `mathplayground/local_settings.py` file in your development environment:
```
CSRF_TRUSTED_ORIGINS = [
    'https://your.url.columbia.edu'
]
```