### PR TITLE
Implement scene object hover/selection for Function object

### DIFF
--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -21,6 +21,9 @@
         blockGeometry,
     } from '../utils.js';
 
+    export let uuid;
+    export let onRenderObject = function() {};
+    export let onDestroyObject = function() {};
     export let camera,
         controls,
         animation = false,
@@ -411,6 +414,12 @@
         } else {
             const backMesh = new THREE.Mesh(geometry, minusMaterial);
             const frontMesh = new THREE.Mesh(geometry, material);
+
+            // Pass in the 3demos-generated uuid so we can keep track
+            // of which object this belongs to.
+            backMesh.name = uuid;
+            frontMesh.name = uuid;
+            onRenderObject(backMesh, frontMesh);
 
             surfaceMesh.add(frontMesh);
             surfaceMesh.add(backMesh);
@@ -892,6 +901,8 @@
         updateBoxes();
     });
     onDestroy(() => {
+        onDestroyObject(...surfaceMesh.children);
+
         for (const child of surfaceMesh.children) {
             child.geometry && child.geometry.dispose();
             child.material && child.material.dispose();

--- a/media/src/sceneUtils.js
+++ b/media/src/sceneUtils.js
@@ -105,10 +105,21 @@ const handleSceneEvent = function(data, objects) {
     return objects;
 };
 
+/**
+ * Given the scene setup and a pointer/mouse event, return the notable
+ * objects in the scene that intersect with this mouse event.
+ */
+const findPointerIntersects = function(objects, pointer, camera, raycaster) {
+    raycaster.setFromCamera(pointer, camera);
+    const intersects = raycaster.intersectObjects(objects, true);
+    return intersects;
+};
+
 export {
     makeObject,
     removeObject,
     updateObject,
     publishScene,
-    handleSceneEvent
+    handleSceneEvent,
+    findPointerIntersects
 };


### PR DESCRIPTION
Each 3demos object has a `uuid` we can use to determine what three.js meshes belong to which "object" created by our UI.

These changes add a new onRenderObject/onDestroyObject api we can use to keep track of the visible three.js meshes in the scene, and how they correspond to the 3demos object created by the user.

Next steps:
* Add this to the rest of the object types
* Add visual indicator that object is selected. Something that will work for all object types like a box around the object. Currently we just have the box in the Object list. Maybe take design cues from Blender: https://docs.blender.org/manual/en/latest/scene_layout/object/selecting.html

Issue #391